### PR TITLE
handle IntlDateFormatter::NONE to return time only

### DIFF
--- a/src/Ranger.php
+++ b/src/Ranger.php
@@ -268,12 +268,18 @@ class Ranger
     {
         $tokens = [];
 
-        $intl = new IntlDateFormatter($this->locale, $this->date_type, IntlDateFormatter::NONE, $date->getTimezone()->getName());
-        $formatted = $intl->format((int) $date->format('U'));
+        $formatted = "";
+        if ($this->date_type !== IntlDateFormatter::NONE) {
+            $intl = new IntlDateFormatter($this->locale, $this->date_type, IntlDateFormatter::NONE, $date->getTimezone()->getName());
+            $formatted .= $intl->format((int) $date->format('U'));
+            if ($this->time_type !== IntlDateFormatter::NONE) {
+                $formatted .= $this->date_time_separator;
+            }
+        }
 
         if ($this->time_type !== IntlDateFormatter::NONE) {
             $intl = new IntlDateFormatter($this->locale, IntlDateFormatter::NONE, $this->time_type, $date->getTimezone()->getName());
-            $formatted .= $this->date_time_separator . $intl->format((int) $date->format('U'));
+            $formatted .= $intl->format((int) $date->format('U'));
         }
 
         $type = null;
@@ -342,12 +348,18 @@ class Ranger
             return;
         }
 
-        $intl = new IntlDateFormatter($this->locale, $this->date_type, IntlDateFormatter::NONE);
-        $pattern = $intl->getPattern();
+        $pattern = "";
+        if ($this->date_type !== IntlDateFormatter::NONE) {
+            $intl = new IntlDateFormatter($this->locale, $this->date_type, IntlDateFormatter::NONE);
+            $pattern .= $intl->getPattern();
+            if ($this->time_type !== IntlDateFormatter::NONE) {
+                $pattern .= "'" . $this->date_time_separator . "'";
+            }
+        }
 
         if ($this->time_type !== IntlDateFormatter::NONE) {
             $intl = new IntlDateFormatter($this->locale, IntlDateFormatter::NONE, $this->time_type);
-            $pattern .= "'" . $this->date_time_separator . "'" . $intl->getPattern();
+            $pattern .= $intl->getPattern();
         }
 
         $esc_active = false;

--- a/src/Ranger.php
+++ b/src/Ranger.php
@@ -331,6 +331,18 @@ class Ranger
             $best_match = self::SECOND;
         }
 
+        // for edge cases where the date differs but is suppressed
+        if ($this->date_type === IntlDateFormatter::NONE 
+            && $best_match < self::DAY) {
+                // redo the am/pm test
+                if ($start->format('a') !== $end->format('a')) {
+                    $best_match = self::DAY;
+                }
+                else {
+                    $best_match = self::AM;
+                }
+        }
+
         //set to same time to avoid DST problems
         $tz_end = clone $end;
         $tz_end->setTimestamp((int) $start->format('U'));
@@ -339,6 +351,7 @@ class Ranger
                 && $best_match < self::DAY)) {
             $best_match = -2;
         }
+
         return $best_match;
     }
 

--- a/src/Ranger.php
+++ b/src/Ranger.php
@@ -310,6 +310,11 @@ class Ranger
      */
     private function find_best_match(DateTime $start, DateTime $end)
     {
+        // ignore the date if it's not output
+        if ($this->date_type === IntlDateFormatter::NONE) {
+            $end->setDate($start->format('Y'), $start->format('m'), $start->format('d'));
+        }
+
         $best_match = -2;
         if ($start->format('Y') !== $end->format('Y')) {
             $best_match = self::TIMEZONE;
@@ -329,18 +334,6 @@ class Ranger
             $best_match = self::AM;
         } else {
             $best_match = self::SECOND;
-        }
-
-        // for edge cases where the date differs but is suppressed
-        if ($this->date_type === IntlDateFormatter::NONE 
-            && $best_match < self::DAY) {
-                // redo the am/pm test
-                if ($start->format('a') !== $end->format('a')) {
-                    $best_match = self::DAY;
-                }
-                else {
-                    $best_match = self::AM;
-                }
         }
 
         //set to same time to avoid DST problems

--- a/src/Ranger.php
+++ b/src/Ranger.php
@@ -269,6 +269,11 @@ class Ranger
         $tokens = [];
 
         $formatted = "";
+        if ($this->date_type === IntlDateFormatter::NONE && $this->time_type === IntlDateFormatter::NONE) {
+            // why would you want this?
+            return $tokens;
+        }
+
         if ($this->date_type !== IntlDateFormatter::NONE) {
             $intl = new IntlDateFormatter($this->locale, $this->date_type, IntlDateFormatter::NONE, $date->getTimezone()->getName());
             $formatted .= $intl->format((int) $date->format('U'));
@@ -310,26 +315,29 @@ class Ranger
      */
     private function find_best_match(DateTime $start, DateTime $end)
     {
+        // make a copy of end because we might change pieces of it
+        $end_copy = clone $end;
+
         // ignore the date if it's not output
         if ($this->date_type === IntlDateFormatter::NONE) {
-            $end->setDate($start->format('Y'), $start->format('m'), $start->format('d'));
+            $end_copy->setDate($start->format('Y'), $start->format('m'), $start->format('d'));
         }
 
         $best_match = -2;
-        if ($start->format('Y') !== $end->format('Y')) {
+        if ($start->format('Y') !== $end_copy->format('Y')) {
             $best_match = self::TIMEZONE;
-        } elseif ($start->format('m') !== $end->format('m')) {
+        } elseif ($start->format('m') !== $end_copy->format('m')) {
             $best_match = self::YEAR;
-        } elseif ($start->format('d') !== $end->format('d')) {
+        } elseif ($start->format('d') !== $end_copy->format('d')) {
             $best_match = self::MONTH;
-        } elseif ($start->format('a') !== $end->format('a')) {
+        } elseif ($start->format('a') !== $end_copy->format('a')) {
             $best_match = self::DAY;
-        } elseif ($start->format('H') !== $end->format('H')) {
+        } elseif ($start->format('H') !== $end_copy->format('H')) {
             $best_match = self::AM;
-        } elseif ($start->format('i') !== $end->format('i')) {
+        } elseif ($start->format('i') !== $end_copy->format('i')) {
             //it makes no sense to display something like 10:00:00 - 30:00...
             $best_match = self::AM;
-        } elseif ($start->format('s') !== $end->format('s')) {
+        } elseif ($start->format('s') !== $end_copy->format('s')) {
             //it makes no sense to display something like 10:00:00 - 30:00...
             $best_match = self::AM;
         } else {
@@ -337,9 +345,8 @@ class Ranger
         }
 
         //set to same time to avoid DST problems
-        $tz_end = clone $end;
-        $tz_end->setTimestamp((int) $start->format('U'));
-        if (   $start->format('T') !== $tz_end->format('T')
+        $end_copy->setTimestamp((int) $start->format('U'));
+        if (   $start->format('T') !== $end_copy->format('T')
             || (   $this->time_type !== IntlDateFormatter::NONE
                 && $best_match < self::DAY)) {
             $best_match = -2;

--- a/test/RangerTest.php
+++ b/test/RangerTest.php
@@ -155,13 +155,28 @@ class RangerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('09.03.2016, 00:00 – 01:00', $formatted);
     }
 
-    public function testNoDate()
+    /**
+     * @dataProvider providerNoDate
+     */
+    public function testNoDate($language, $start, $end, $expected)
     {
-        $ranger = new Ranger('en');
-        $ranger
+        $formatter = new Ranger($language);
+        $formatter
             ->setDateType(IntlDateFormatter::NONE)
             ->setTimeType(IntlDateFormatter::SHORT);
-        $formatted = $ranger->format('2013-10-05 10:00:00', '2013-10-05 13:30:00');
-        $this->assertEquals('10:00 AM – 1:30 PM', $formatted);
+        $this->assertEquals($expected, $formatter->format($start, $end));
     }
+
+    public function providerNoDate()
+    {
+        return [
+            ['en', '2013-10-05 10:00:00', '2013-10-05 13:30:00', '10:00 AM – 1:30 PM'],
+            ['en', '2013-10-05 12:20:00', '2013-10-05 13:30:00', '12:20 – 1:30 PM'],
+            ['en', '12:20:00', '13:30:00', '12:20 – 1:30 PM'],
+            // get a little weird
+            ['en', '2013-10-05 12:20:00', '2013-10-07 13:30:00', '12:20 – 1:30 PM'],
+            ['en', '2012-06-05 10:20:00', '2013-10-07 13:30:00', '10:20 AM – 1:30 PM'], 
+        ];
+    }
+
 }

--- a/test/RangerTest.php
+++ b/test/RangerTest.php
@@ -194,4 +194,19 @@ class RangerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Jan 10–17, 2012', $formatted);
     }
 
+    public function testNoMutation2() 
+    {
+        // checks same as above but a different approach
+        $start = new \DateTime('2012-01-10 10:00:00');
+        $end = new \DateTime('2012-01-17 11:00:00');
+        $r = new Ranger('en');
+        $r->setDateType(\IntlDateFormatter::MEDIUM);
+        $v1 = $r->format($start, $end);
+        $r->setDateType(\IntlDateFormatter::NONE);
+        $r->format($start, $end);
+        $r->setDateType(\IntlDateFormatter::MEDIUM);
+        $v2 = $r->format($start, $end);
+        $this->assertEquals($v1, $v2);
+    }
+
 }

--- a/test/RangerTest.php
+++ b/test/RangerTest.php
@@ -179,4 +179,19 @@ class RangerTest extends PHPUnit_Framework_TestCase
         ];
     }
 
+    public function testNoMutation() 
+    {
+        // changing formats should not change the stored dates
+        $start = new \DateTime('2012-01-10 10:00:00');
+        $end = new \DateTime('2012-01-17 11:00:00');
+        $r = new Ranger('en');
+        $r->setDateType(\IntlDateFormatter::NONE);
+        $r->setTimeType(\IntlDateFormatter::SHORT);
+        $r->format($start, $end);
+        $r->setDateType(\IntlDateFormatter::MEDIUM);
+        $r->setTimeType(\IntlDateFormatter::NONE);
+        $formatted = $r->format($start, $end);
+        $this->assertEquals('Jan 10–17, 2012', $formatted);
+    }
+
 }

--- a/test/RangerTest.php
+++ b/test/RangerTest.php
@@ -161,7 +161,7 @@ class RangerTest extends PHPUnit_Framework_TestCase
         $ranger
             ->setDateType(IntlDateFormatter::NONE)
             ->setTimeType(IntlDateFormatter::SHORT);
-            $formatted = $ranger->format('2013-10-05 10:00:00', '2013-10-05 13:30:00');
-        $this->assertEquals('10:00 AM - 1:30 PM', $formatted);
+        $formatted = $ranger->format('2013-10-05 10:00:00', '2013-10-05 13:30:00');
+        $this->assertEquals('10:00 AM – 1:30 PM', $formatted);
     }
 }

--- a/test/RangerTest.php
+++ b/test/RangerTest.php
@@ -154,4 +154,14 @@ class RangerTest extends PHPUnit_Framework_TestCase
         date_default_timezone_set($backup);
         $this->assertEquals('09.03.2016, 00:00 – 01:00', $formatted);
     }
+
+    public function testNoDate()
+    {
+        $ranger = new Ranger('en');
+        $ranger
+            ->setDateType(IntlDateFormatter::NONE)
+            ->setTimeType(IntlDateFormatter::SHORT);
+            $formatted = $ranger->format('2013-10-05 10:00:00', '2013-10-05 13:30:00');
+        $this->assertEquals('10:00 AM - 1:30 PM', $formatted);
+    }
 }


### PR DESCRIPTION
I noticed time-only output is not handled. This might be out of scope, but this PR adds a test and some conditionals to remove separators if the date_type is NONE.