### PR TITLE
Allow using Symfony 7 dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "symfony/intl": "~2.6|~3.4|~4.0|~5.0|~6.0"
+        "symfony/intl": "~2.6|~3.4|~4.0|~5.0|~6.0|~7.0"
     },
     "suggest": {
         "ext-intl": "Needed for usage with other locales than 'en'"


### PR DESCRIPTION
I use your nice package in a Symfony application that I'm updating to Symfony 7. So, I propose this PR to allow installing this package in Symfony 7 applications.

Note: Symfony 7 releases at the end of November 2023 (see https://symfony.com/releases/7.0) but changes like these are needed so we can test the apps before the Symfony 7 release. Thanks!